### PR TITLE
Create package name with period between Id and Version instead of space

### DIFF
--- a/src/NuGetPackager/PackageCreator.cs
+++ b/src/NuGetPackager/PackageCreator.cs
@@ -97,12 +97,12 @@
                     packageBuilder.PopulateFiles("", manifest.Files);
             }
 
-            SavePackage(packageBuilder, destinationFolderFullPath, ".nupkg", "Package created -> {0}");
+            SavePackage(packageBuilder, destinationFolderFullPath, "Package created -> {0}");
         }
 
-        void SavePackage(PackageBuilder packageBuilder, string destinationFolder, string filenameSuffix, string logMessage)
+        void SavePackage(PackageBuilder packageBuilder, string destinationFolder, string logMessage)
         {
-            var filename = Path.Combine(destinationFolder, packageBuilder.GetFullName()) + filenameSuffix;
+            var filename = Path.Combine(destinationFolder, $"{packageBuilder.Id}.{packageBuilder.Version}.nupkg");
 
             if (!Directory.Exists(destinationFolder))
                 Directory.CreateDirectory(destinationFolder);


### PR DESCRIPTION
The `GetFullName` extension method currently being used to create the package file name does so in the following way:

```csharp
return (package.Id + " " + package.Version);
```

NuGet packages should use a period to separate the name and the version, so this changes how the filename is created to match this convention.
